### PR TITLE
Refactor model downloading process; move logic to a separate script f…

### DIFF
--- a/.github/workflows/data-labeling.yml
+++ b/.github/workflows/data-labeling.yml
@@ -47,20 +47,7 @@ jobs:
       - name: ⬇️ Download models if not cached
         run: |
           mkdir -p ~/.hf_models/sentiment ~/.hf_models/emotion
-          python -c "
-            import os
-            from transformers import AutoTokenizer, AutoModelForSequenceClassification
-
-            sentiment_path = os.path.expanduser('~/.hf_models/sentiment')
-            if not os.path.exists(os.path.join(sentiment_path, 'config.json')):
-                AutoTokenizer.from_pretrained('cardiffnlp/twitter-roberta-base-sentiment').save_pretrained(sentiment_path)
-                AutoModelForSequenceClassification.from_pretrained('cardiffnlp/twitter-roberta-base-sentiment').save_pretrained(sentiment_path)
-
-            emotion_path = os.path.expanduser('~/.hf_models/emotion')
-            if not os.path.exists(os.path.join(emotion_path, 'config.json')):
-                AutoTokenizer.from_pretrained('j-hartmann/emotion-english-distilroberta-base').save_pretrained(emotion_path)
-                AutoModelForSequenceClassification.from_pretrained('j-hartmann/emotion-english-distilroberta-base').save_pretrained(emotion_path)
-            "
+          python scripts/download_model_gh_action.py
 
       - name: 🐳 Setup Python
         uses: actions/setup-python@v4

--- a/scripts/download_model_gh_action.py
+++ b/scripts/download_model_gh_action.py
@@ -1,0 +1,13 @@
+import os
+from transformers import AutoTokenizer, AutoModelForSequenceClassification
+
+sentiment_path = os.path.expanduser('~/.hf_models/sentiment')
+
+if not os.path.exists(os.path.join(sentiment_path, 'config.json')):
+    AutoTokenizer.from_pretrained('cardiffnlp/twitter-roberta-base-sentiment').save_pretrained(sentiment_path)
+    AutoModelForSequenceClassification.from_pretrained('cardiffnlp/twitter-roberta-base-sentiment').save_pretrained(sentiment_path)
+
+emotion_path = os.path.expanduser('~/.hf_models/emotion')
+if not os.path.exists(os.path.join(emotion_path, 'config.json')):
+    AutoTokenizer.from_pretrained('j-hartmann/emotion-english-distilroberta-base').save_pretrained(emotion_path)
+    AutoModelForSequenceClassification.from_pretrained('j-hartmann/emotion-english-distilroberta-base').save_pretrained(emotion_path)


### PR DESCRIPTION
This pull request refactors the workflow for downloading models used in data labeling by moving the model download logic into a standalone Python script. This change simplifies the workflow file and improves maintainability by isolating the download logic.

Workflow simplification:

* [`.github/workflows/data-labeling.yml`](diffhunk://#diff-29335d556de8a986368e8acbea3776f760031c2d2e7be8467ab2881b402e1548L50-R50): Replaced the inline Python script for downloading models with a call to the standalone script `scripts/download_model_gh_action.py`. This reduces clutter in the workflow file.

Code isolation:

* [`scripts/download_model_gh_action.py`](diffhunk://#diff-91652eb6a47b18a492b163e6c94f54bf1857ff4329dc9b79558d0d67cf02485fR1-R13): Added a new script that encapsulates the logic for downloading sentiment and emotion models. This script ensures the models are saved locally if not already cached.…or better organization